### PR TITLE
Syntax file for SWIG - Modifications

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -590,18 +590,27 @@ export def FTprogress_cweb()
   endif
 enddef
 
+# These include the leading '%' sign
+var ft_swig_keywords = '^\s*%\%(addmethods\|apply\|beginfile\|clear\|constant\|define\|echo\|enddef\|endoffile\|extend\|feature\|fragment\|ignore\|import\|importfile\|include\|includefile\|inline\|insert\|keyword\|module\|name\|namewarn\|native\|newobject\|parms\|pragma\|rename\|template\|typedef\|typemap\|types\|varargs\|warn\)'
+# This is the start/end of a block that is copied literally to the processor file (C/C++)
+var ft_swig_verbatim_block_start = '^\s*%{'
+var ft_swig_verbatim_block_end = '^\s*}%'
+
 export def FTprogress_asm()
   if exists("g:filetype_i")
     exe "setf " .. g:filetype_i
     return
   endif
-  # This function checks for an assembly comment the first ten lines.
+  # This function checks for an assembly comment or a SWIG keyword or verbatim block in the first 50 lines.
   # If not found, assume Progress.
   var lnum = 1
-  while lnum <= 10 && lnum < line('$')
+  while lnum <= 50 && lnum < line('$')
     var line = getline(lnum)
     if line =~ '^\s*;' || line =~ '^\*'
       FTasm()
+      return
+    elseif line =~ ft_swig_keywords || line =~ ft_swig_verbatim_block_start || line =~ ft_swig_verbatim_block_end
+      setf swig
       return
     elseif line !~ '^\s*$' || line =~ '^/\*'
       # Not an empty line: Doesn't look like valid assembly code.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1688,7 +1688,7 @@ au BufNewFile,BufRead .procmail,.procmailrc	setf procmail
 " Progress or CWEB
 au BufNewFile,BufRead *.w			call dist#ft#FTprogress_cweb()
 
-" Progress or assembly
+" Progress or assembly or Swig
 au BufNewFile,BufRead *.i			call dist#ft#FTprogress_asm()
 
 " Progress or Pascal
@@ -2184,7 +2184,7 @@ au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 au BufNewFile,BufRead *.sil			call dist#ft#FTsil()
 
 " Swig
-autocmd BufNewFile,BufRead *.i,*.swg,*.swig set filetype=swig
+au BufNewFile,BufRead *.swg,*.swig set filetype=swig
 
 " Sysctl
 au BufNewFile,BufRead */etc/sysctl.conf,*/etc/sysctl.d/*.conf	setf sysctl

--- a/runtime/syntax/swig.vim
+++ b/runtime/syntax/swig.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:	SWIG
 " Maintainer:	Roman Stanchak (rstanchak@yahoo.com)
-" Last Change:	2023 April 27
+" Last Change:	2023 November 23
 
 if exists("b:current_syntax")
-	finish
+  finish
 endif
 
 " Read the C++ syntax to start with
@@ -12,17 +12,34 @@ runtime! syntax/cpp.vim
 unlet b:current_syntax
 
 " SWIG extentions
-syn keyword swigDirective %typemap %define %apply %fragment %include %enddef %extend %newobject %name
-syn keyword swigDirective %rename %ignore %keyword %typemap %define %apply %fragment %include
-syn keyword swigDirective %enddef %extend %newobject %name %rename %ignore %template %module %constant
-syn match swigDirective "%\({\|}\)"
+syn keyword swigMostCommonDirective %addmethods %apply %beginfile %clear %constant %define %echo %enddef %endoffile
+syn keyword swigMostCommonDirective %extend %feature %fragment %ignore %import %importfile %include %includefile %inline
+syn keyword swigMostCommonDirective %insert %keyword %module %name %namewarn %native %newobject %parms %pragma
+syn keyword swigMostCommonDirective %rename %template %typedef %typemap %types %varargs %warn
+syn keyword swigDirective %aggregate_check %alias %allocators %allowexception %array_class %array_functions %attribute %attribute2 %attribute2ref
+syn keyword swigDirective %attribute_ref %attributeref %attributestring %attributeval %auto_ptr %bang %bar %begin %callback
+syn keyword swigDirective %catches %cdata %cleardirector %clearimmutable %contract %copyctor %csattributes %csconst %csconstvalue
+syn keyword swigDirective %csmethodmodifiers %csnothrowexception %cstring_bounded_mutable %cstring_bounded_output %cstring_chunk_output %cstring_input_binary %cstring_mutable %cstring_output_allocate %cstring_output_allocate_size
+syn keyword swigDirective %cstring_output_maxsize %cstring_output_withsize %cwstring_bounded_mutable %cwstring_bounded_output %cwstring_chunk_output %cwstring_input_binary %cwstring_mutable %cwstring_output_allocate %cwstring_output_allocate_size
+syn keyword swigDirective %cwstring_output_maxsize %cwstring_output_withsize %dconstvalue %delete_array %delobject %director %dmanifestconst %dmethodmodifiers %exception
+syn keyword swigDirective %exceptionclass %extend_smart_pointer %factory %fastdispatch %free %freefunc %go_import %header %immutable
+syn keyword swigDirective %implicit %implicitconv %init %interface %interface_custom %interface_impl %intrusive_ptr %intrusive_ptr_no_wrap %javaconst
+syn keyword swigDirective %javaconstvalue %javaexception %javamethodmodifiers %luacode %malloc %markfunc %minit %mshutdown %multiple_values
+syn keyword swigDirective %mutable %naturalvar %nocallback %nocopyctor %nodefaultctor %nodefaultdtor %nojavaexception %nonaturalvar %nonspace
+syn keyword swigDirective %nspace %pointer_cast %pointer_class %pointer_functions %predicate %proxycode %pybinoperator %pybuffer_binary %pybuffer_mutable_binary
+syn keyword swigDirective %pybuffer_mutable_string %pybuffer_string %pythonappend %pythonbegin %pythoncode %pythondynamic %pythonnondynamic %pythonprepend %raise
+syn keyword swigDirective %refobject %remane %rinit %rshutdown %runtime %scilabconst %set_output %shared_ptr %std_comp_methods
+syn keyword swigDirective %std_nodefconst_type %trackobjects %typecheck %typemaps_string %unique_ptr %unrefobject %values_as_list %values_as_vector %valuewrapper
+syn keyword swigDirective %warnfilter %wrapper
+
+syn match swigVerbatim "%\({\|}\)"
 syn match swigUserDef "%[-_a-zA-Z0-9]\+"
 
 " Default highlighting
-command -nargs=+ HiLink hi def link <args>
-HiLink swigDirective	Exception
-HiLink swigUserDef 		PreProc
-delcommand HiLink
+hi def link swigMostCommonDirective Exception
+hi def link swigDirective Exception
+hi def link swigVerbatim Exception
+hi def link swigUserDef PreProc
 
 let b:current_syntax = "swig"
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -673,6 +673,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     swayconfig: ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
     swift: ['file.swift'],
     swiftgyb: ['file.swift.gyb'],
+    swig: ['file.swg', 'file.swig'],
     sysctl: ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],
     systemd: ['any/systemd/file.automount', 'any/systemd/file.dnssd',
               'any/systemd/file.link', 'any/systemd/file.mount',
@@ -2335,6 +2336,32 @@ func Test_vba_file()
   call writefile(['" Vimball Archiver by Charles E. Campbell, Ph.D.', 'UseVimball', 'finish'], 'Xfile.vba', 'D')
   split Xfile.vba
   call assert_equal('vim', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_swig_file()
+  filetype on
+
+  " Swig
+
+  call writefile(['%module mymodule'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('swig', &filetype)
+  bwipe!
+
+  " Swig
+
+  call writefile(['%{', '#include <header.hpp>", '%}'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('swig', &filetype)
+  bwipe!
+
+  " ASM
+  call writefile(['; comment'], 'Xfile.i', 'D')
+  split Xfile.i
+  call assert_equal('asm', &filetype)
   bwipe!
 
   filetype off


### PR DESCRIPTION
* Ref https://github.com/vim/vim/pull/13540
* Add detection of swig when .i file + test (not sure if they pass! don't have time to figure out why it doesn't build)
* More keyword. The most common ones are from parsing swig/Source/CParse/ and the extended ones are from parsing the swig/Examples files (removing user-defined ones)


```python
from pathlib import Path
import re
swig_examples = Path('/path/to/swig/Examples')
RE_PCT = re.compile(r'\s*(%\w+)')
RE_USER_DEFINED = re.compile(r'\s*%define\s+(%\w+)\(')

all_matches = []
user_defined = []
for fpath in list(swig_examples.glob('**/*.i')):
    try:
        for line in fpath.read_text().splitlines():
            if m := RE_PCT.match(line):
                all_matches.append(m.groups()[0])
            if m := RE_USER_DEFINED.match(line):
                user_defined.append(m.groups()[0])
    except:
        print(fpath)
        
all_matches = set(all_matches)
user_defined = set(user_defined)

print(len(all_matches), len(user_defined))

all_matches = all_matches - user_defined
print(len(all_matches)) # 154
```